### PR TITLE
Issue 21 and other fixes

### DIFF
--- a/addons/PlayerCharacter/StateMachine/crouch_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/crouch_state_script.gd
@@ -17,11 +17,15 @@ func verifications() -> void:
 	play_char.move_deccel = play_char.crouch_deccel
 	
 	play_char.floor_snap_length = 1.0
-	if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
-	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
-	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
-	if play_char.has_dashed: play_char.has_dashed = false
-	if play_char.last_wallrunned_wall_out_of_time != 0: play_char.last_wallrunned_wall_out_of_time = 0
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
+	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref:
+		play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
+	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref:
+		play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
+	if play_char.has_dashed:
+		play_char.has_dashed = false
+	if play_char.last_wallrunned_wall_out_of_time != 0:
+		play_char.last_wallrunned_wall_out_of_time = 0
 	
 	play_char.tween_hitbox_height(play_char.crouch_hitbox_height)
 	play_char.tween_model_height(play_char.crouch_model_height)
@@ -37,20 +41,23 @@ func physics_update(delta : float) -> void:
 	
 func applies(delta : float) -> void:
 	if play_char.hit_ground_cooldown > 0.0: play_char.hit_ground_cooldown -= delta
-	
+
+	#Fix to make jump_cooldown run in this state.
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
+
 	if !play_char.is_on_floor() and !play_char.is_on_wall():
 		if play_char.velocity.y < 0.0:
 			transitioned.emit(self, "InairState")
 			
 	if play_char.is_on_floor():
-		if play_char.jump_buff_on and play_char.jump_cooldown < 0.0:
+		if play_char.jump_buff_on and play_char.jump_cooldown <= 0.0:
 			play_char.buffered_jump = true
 			play_char.jump_buff_on = false
 			transitioned.emit(self, "JumpState")
 	
 func input_management() -> void:
 	if Input.is_action_just_pressed(play_char.jump_action):
-		if play_char.jump_cooldown < 0.0 and !raycast_verification(): #if nothing block the player character when it will leaves the play_charouch state
+		if play_char.jump_cooldown <= 0.0 and !raycast_verification(): #if nothing block the player character when it will leaves the play_charouch state
 			transitioned.emit(self, "JumpState")
 			
 	if play_char.continious_crouch: 

--- a/addons/PlayerCharacter/StateMachine/dash_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/dash_state_script.gd
@@ -27,6 +27,9 @@ func physics_update(delta : float):
 	move()
 	
 func applies(delta : float):
+	#Fix to make jump_cooldown run in this state.
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
+
 	if play_char.dash_time > 0.0: 
 		play_char.dash_time -= delta
 	else:
@@ -40,7 +43,7 @@ func applies(delta : float):
 			transitioned.emit(self, play_char.walk_or_run)
 		else:
 			transitioned.emit(self, "InairState")
-			
+
 func move():
 	#can't change direction while dashing
 	if play_char.dash_direction != Vector3.ZERO:

--- a/addons/PlayerCharacter/StateMachine/fly_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/fly_state_script.gd
@@ -21,7 +21,7 @@ func verifications() -> void:
 	fly_deccel = play_char.fly_deccel
 	
 	play_char.floor_snap_length = 1.0
-	if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
 	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
 	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
 	if play_char.has_dashed: play_char.has_dashed = false
@@ -37,6 +37,9 @@ func physics_update(delta : float) -> void:
 	move(delta)
 	
 func applies(delta : float) -> void:
+	#Fix to make jump_cooldown run in this state.
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
+
 	if play_char.hit_ground_cooldown > 0.0: play_char.hit_ground_cooldown -= delta
 	
 func input_management() -> void:

--- a/addons/PlayerCharacter/StateMachine/idle_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/idle_state_script.gd
@@ -13,10 +13,16 @@ func enter(play_char_ref : CharacterBody3D):
 	verifications()
 	
 func verifications():
+	#Fix for sliding after slide, jump, releasing in air.
+	#if play_char.input_direction == Vector2.ZERO:
+		#play_char.velocity.x = 0
+		#play_char.velocity.z = 0
 	#manage the appliements that need to be set at the start of the state
 	play_char.floor_snap_length = 1.0
-	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
-	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
+	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: 
+		play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
+	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: 
+		play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
 	if play_char.has_dashed: play_char.has_dashed = false
 	if play_char.last_wallrunned_wall_out_of_time != 0: play_char.last_wallrunned_wall_out_of_time = 0
 	
@@ -37,15 +43,16 @@ func applies(delta : float):
 	if play_char.hit_ground_cooldown > 0.0: play_char.hit_ground_cooldown -= delta
 	
 	#i don't know why, but if i put this line in verifications, it broke the jump cooldown, because he constantly stay at -1.0
-	if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
-	
+#	This broke because you allow jump if play_char.jump_cooldown is <0, it won't pick up 0. Set <= 0 so it jumps at 0 in the input_management. However, you now need to lower the jump cooldown at all times.
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
 	#manage the appliements and state transitions that needs to be sets/checked/performed
 	#every time the play char pass through one of the following : floor-inair-onwall
 	if !play_char.is_on_floor() and !play_char.is_on_wall():
 		transitioned.emit(self, "InairState")
 		
 	if play_char.is_on_floor():
-		if play_char.jump_buff_on and play_char.jump_cooldown < 0.0: 
+		if play_char.jump_buff_on and play_char.jump_cooldown <= 0.0: 
 			play_char.buffered_jump = true
 			play_char.jump_buff_on = false
 			transitioned.emit(self, "JumpState")
@@ -53,7 +60,7 @@ func applies(delta : float):
 func input_management():
 	#manage the state transitions depending on the actions inputs
 	if Input.is_action_just_pressed(play_char.jump_action):
-		if play_char.jump_cooldown < 0.0:
+		if play_char.jump_cooldown <= 0.0:
 			transitioned.emit(self, "JumpState")
 		
 	if Input.is_action_just_pressed(play_char.crouch_action):
@@ -73,7 +80,7 @@ func move(delta : float):
 	play_char.input_direction = Input.get_vector(play_char.move_left_action, play_char.move_right_action, play_char.move_forward_action, play_char.move_backward_action)
 	#get the move direction depending on the input
 	play_char.move_direction = (play_char.cam_holder.global_basis * Vector3(play_char.input_direction.x, 0.0, play_char.input_direction.y)).normalized()
-	
+
 	#set to ensure the character don't exceed the max speed authorized
 	play_char.desired_move_speed = clamp(play_char.desired_move_speed, 0.0, play_char.max_desired_move_speed)
 	
@@ -82,8 +89,8 @@ func move(delta : float):
 		transitioned.emit(self, play_char.walk_or_run)
 	else:
 		#apply smooth stop 
-		play_char.velocity.x = lerp(play_char.velocity.x, 0.0, play_char.move_deccel * delta)
-		play_char.velocity.z = lerp(play_char.velocity.z, 0.0, play_char.move_deccel * delta)
+		play_char.velocity.x = lerp(play_char.velocity.x, 0.0, play_char.idle_deccel * delta)
+		play_char.velocity.z = lerp(play_char.velocity.z, 0.0, play_char.idle_deccel * delta)
 		
 		#cancel desired move speed accumulation if the timer has elapsed (is up)
 		if play_char.hit_ground_cooldown <= 0: play_char.desired_move_speed = play_char.velocity.length()

--- a/addons/PlayerCharacter/StateMachine/inair_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/inair_state_script.gd
@@ -31,7 +31,7 @@ func physics_update(delta : float) -> void:
 	
 func applies(delta : float) -> void:
 	if !play_char.is_on_floor(): 
-		if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
+		#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
 		if play_char.coyote_jump_cooldown > 0.0: play_char.coyote_jump_cooldown -= delta
 		if play_char.walljump_lock_in_air_movement_time > 0.0: play_char.walljump_lock_in_air_movement_time -= delta
 		
@@ -52,10 +52,10 @@ func input_management() -> void:
 		#check if can jump buffer
 		if play_char.floor_check.is_colliding() and play_char.last_frame_position.y > play_char.position.y and play_char.nb_jumps_in_air_allowed <= 0: play_char.jump_buff_on = true
 		#check if can coyote jump
-		if play_char.was_on_floor and play_char.coyote_jump_cooldown > 0.0 and play_char.last_frame_position.y > play_char.position.y and play_char.jump_cooldown < 0.0:
+		if play_char.was_on_floor and play_char.coyote_jump_cooldown > 0.0 and play_char.last_frame_position.y > play_char.position.y and play_char.jump_cooldown <= 0.0:
 			play_char.coyote_jump_on = true
 			transitioned.emit(self, "JumpState")
-		if play_char.jump_cooldown < 0.0:
+		if play_char.jump_cooldown <= 0.0:
 			transitioned.emit(self, "JumpState")
 		
 	if Input.is_action_just_pressed(play_char.dash_action):

--- a/addons/PlayerCharacter/StateMachine/jump_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/jump_state_script.gd
@@ -18,8 +18,10 @@ func enter(play_char_ref : CharacterBody3D) -> void:
 	
 func verifications() -> void:
 	if play_char.floor_snap_length != 0.0:  play_char.floor_snap_length = 0.0
-	if play_char.jump_cooldown < play_char.jump_cooldown_ref: play_char.jump_cooldown = play_char.jump_cooldown_ref
-	if play_char.hit_ground_cooldown != play_char.hit_ground_cooldown_ref: play_char.hit_ground_cooldown = play_char.hit_ground_cooldown_ref
+	if play_char.jump_cooldown < play_char.jump_cooldown_ref:
+		play_char.jump_cooldown = play_char.jump_cooldown_ref
+	if play_char.hit_ground_cooldown != play_char.hit_ground_cooldown_ref:
+		play_char.hit_ground_cooldown = play_char.hit_ground_cooldown_ref
 	
 	play_char.tween_hitbox_height(play_char.base_hitbox_height)
 	play_char.tween_model_height(play_char.base_model_height)
@@ -37,7 +39,6 @@ func physics_update(delta : float) -> void:
 	
 func applies(delta : float) -> void:
 	if !play_char.is_on_floor(): 
-		if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
 		if play_char.coyote_jump_cooldown > 0.0: play_char.coyote_jump_cooldown -= delta
 		if play_char.walljump_lock_in_air_movement_time > 0.0: play_char.walljump_lock_in_air_movement_time -= delta
 		if play_char.velocity.y < 0.0: transitioned.emit(self, "InairState")
@@ -48,7 +49,7 @@ func applies(delta : float) -> void:
 		
 func input_management() -> void:
 	if Input.is_action_just_pressed(play_char.jump_action):
-		if play_char.jump_cooldown < 0.0:
+		if play_char.jump_cooldown <= 0.0:
 			jump()
 		
 	if Input.is_action_just_pressed(play_char.dash_action):
@@ -82,7 +83,8 @@ func move(delta : float) -> void:
 	
 	if !play_char.is_on_floor():
 		if play_char.move_direction:
-			if play_char.desired_move_speed < play_char.max_desired_move_speed: play_char.desired_move_speed += play_char.bunny_hop_dms_incre * delta
+			if play_char.desired_move_speed < play_char.max_desired_move_speed:
+				play_char.desired_move_speed += play_char.bunny_hop_dms_incre * delta
 			
 			#use of curves here to have a better in air movement
 			var contrd_des_move_speed : float = play_char.desired_move_speed_curve.sample(play_char.desired_move_speed)

--- a/addons/PlayerCharacter/StateMachine/player_character_script.gd
+++ b/addons/PlayerCharacter/StateMachine/player_character_script.gd
@@ -25,6 +25,9 @@ var walk_or_run: String = "WalkState" #keep in memory if play char was walking o
 @export var base_model_height: float = 1.0
 @export var height_change_duration: float = 0.15
 
+@export_group("Idle variables")
+@export var idle_deccel: float = 10.0
+
 @export_group("Crouch variables")
 @export var crouch_speed: float = 6.0
 @export var crouch_accel: float = 12.0
@@ -58,6 +61,7 @@ var buffered_jump: bool = false
 @export var coyote_jump_cooldown: float = 0.3
 var coyote_jump_cooldown_ref: float
 var coyote_jump_on: bool = false
+var released_input_in_air: bool = false
 
 @export_group("Slide variables")
 var slide_direction: Vector3 = Vector3.ZERO
@@ -163,7 +167,6 @@ func _ready() -> void:
 	#set and value references
 	hit_ground_cooldown_ref = hit_ground_cooldown
 	jump_cooldown_ref = jump_cooldown
-	jump_cooldown = -1.0
 	nb_jumps_in_air_allowed_ref = nb_jumps_in_air_allowed
 	coyote_jump_cooldown_ref = coyote_jump_cooldown
 	slide_time_ref = slide_time
@@ -223,19 +226,25 @@ func input_actions_check() -> void:
 					var input_event_key = InputEventKey.new()
 					input_event_key.physical_keycode = keycode
 					InputMap.action_add_event(input_action, input_event_key)
-				
+
 func _process(delta: float) -> void:
 	wallrun_timer(delta)
-	
+
 	slide_timer(delta)
 
 	dash_timer(delta)
-	
+
+	jump_timer(delta)
+
 func _physics_process(_delta: float) -> void:
 	modify_physics_properties()
 
 	move_and_slide()
-	
+
+func jump_timer(delta : float) -> void:
+	if jump_cooldown > 0.0:
+		jump_cooldown -= delta
+
 func wallrun_timer(delta : float) -> void:
 	if !can_wallrun:
 		if time_bef_can_wallrun_again > 0.0: time_bef_can_wallrun_again -= delta
@@ -263,7 +272,7 @@ func dash_timer(delta: float) -> void:
 
 	if time_bef_can_dash_again > 0.0: time_bef_can_dash_again -= delta
 	else:
-		#can only reset slide time when not dashing
+		#can only reset dash time when not dashing
 		if state_machine.curr_state_name != "Dash":
 			dash_time = dash_time_ref
 			

--- a/addons/PlayerCharacter/StateMachine/run_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/run_state_script.gd
@@ -17,7 +17,7 @@ func verifications() -> void:
 	play_char.move_deccel = play_char.run_deccel
 	
 	if play_char.floor_snap_length != 1.0: play_char.floor_snap_length = 1.0
-	if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
 	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
 	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
 	if play_char.has_dashed: play_char.has_dashed = false
@@ -36,6 +36,9 @@ func physics_update(delta : float) -> void:
 	move(delta)
 	
 func applies(delta : float) -> void:
+	#Fix to make jump_cooldown run in this state.
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
+
 	if play_char.hit_ground_cooldown > 0.0: play_char.hit_ground_cooldown -= delta
 	
 	if !play_char.is_on_floor():
@@ -43,16 +46,16 @@ func applies(delta : float) -> void:
 			transitioned.emit(self, "InairState")
 			
 	if play_char.is_on_floor():
-		if play_char.auto_bunny_hop and play_char.hit_ground_cooldown > 0.0 and play_char.input_direction != Vector2.ZERO and play_char.jump_cooldown < 0.0:
+		if play_char.auto_bunny_hop and play_char.hit_ground_cooldown > 0.0 and play_char.input_direction != Vector2.ZERO and play_char.jump_cooldown <= 0.0:
 			transitioned.emit(self, "JumpState")
-		if play_char.jump_buff_on and play_char.jump_cooldown < 0.0:
+		if play_char.jump_buff_on and play_char.jump_cooldown <= 0.0:
 			play_char.buffered_jump = true
 			play_char.jump_buff_on = false
 			transitioned.emit(self, "JumpState")
 	
 func input_management() -> void:
 	if Input.is_action_just_pressed(play_char.jump_action):
-		if play_char.jump_cooldown < 0.0:
+		if play_char.jump_cooldown <= 0.0:
 			transitioned.emit(self, "JumpState")
 		
 	if Input.is_action_just_pressed(play_char.crouch_action) and !play_char.priority_over_crouch:

--- a/addons/PlayerCharacter/StateMachine/slide_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/slide_state_script.gd
@@ -21,11 +21,14 @@ func verifications() -> void:
 	play_char.slide_direction = play_char.move_direction.normalized() #get move direction before actually start sliding, and stick to that direction
 	
 	if play_char.floor_snap_length != 1.0: play_char.floor_snap_length = 1.0
-	if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
-	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
-	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
+	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: 
+		play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
+	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: 
+		play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
 	if play_char.has_dashed: play_char.has_dashed = false
-	if play_char.last_wallrunned_wall_out_of_time != 0: play_char.last_wallrunned_wall_out_of_time = 0
+	if play_char.last_wallrunned_wall_out_of_time != 0: 
+		play_char.last_wallrunned_wall_out_of_time = 0
 	
 	play_char.tween_hitbox_height(play_char.slide_hitbox_height)
 	play_char.tween_model_height(play_char.slide_model_height)
@@ -65,7 +68,7 @@ func applies(delta : float) -> void:
 				transitioned.emit(self, "CrouchState")
 				
 	if play_char.is_on_floor():
-		if play_char.jump_buff_on and play_char.jump_cooldown < 0.0:
+		if play_char.jump_buff_on and play_char.jump_cooldown <= 0.0:
 			play_char.buffered_jump = true
 			play_char.jump_buff_on = false
 			transitioned.emit(self, "JumpState")
@@ -73,7 +76,7 @@ func applies(delta : float) -> void:
 func input_management() -> void:
 	if Input.is_action_just_pressed(play_char.jump_action):
 		#if nothing block play char when he will leave the slide state
-		if (slope_angle > play_char.max_slope_angle or !raycast_verification()) and play_char.jump_cooldown < 0.0:
+		if (slope_angle > play_char.max_slope_angle or !raycast_verification()) and play_char.jump_cooldown <= 0.0:
 			#force break slide state
 			play_char.slide_time = -1.0
 			play_char.slide_direction = Vector3.ZERO

--- a/addons/PlayerCharacter/StateMachine/walk_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/walk_state_script.gd
@@ -17,7 +17,7 @@ func verifications() -> void:
 	play_char.move_deccel = play_char.walk_deccel
 	 
 	play_char.floor_snap_length = 1.0
-	if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
 	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
 	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
 	if play_char.has_dashed: play_char.has_dashed = false
@@ -37,16 +37,16 @@ func physics_update(delta : float) -> void:
 	
 func applies(delta : float) -> void:
 	if play_char.hit_ground_cooldown > 0.0: play_char.hit_ground_cooldown -= delta
-	
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
 	if !play_char.is_on_floor() and !play_char.is_on_wall():
 		if play_char.velocity.y < 0.0:
 			transitioned.emit(self, "InairState")
 			
 	if play_char.is_on_floor():
 		#check if can auto bunny hop
-		if play_char.auto_bunny_hop and play_char.hit_ground_cooldown > 0.0 and play_char.input_direction != Vector2.ZERO and play_char.jump_cooldown < 0.0:
+		if play_char.auto_bunny_hop and play_char.hit_ground_cooldown > 0.0 and play_char.input_direction != Vector2.ZERO and play_char.jump_cooldown <= 0.0:
 			transitioned.emit(self, "JumpState")
-		if play_char.jump_buff_on and play_char.jump_cooldown < 0.0:
+		if play_char.jump_buff_on and play_char.jump_cooldown <= 0.0:
 			#apply jump buffering
 			play_char.buffered_jump = true
 			play_char.jump_buff_on = false
@@ -54,7 +54,7 @@ func applies(delta : float) -> void:
 	
 func input_management() -> void:
 	if Input.is_action_just_pressed(play_char.jump_action):
-		if play_char.jump_cooldown < 0.0:
+		if play_char.jump_cooldown <= 0.0:
 			transitioned.emit(self, "JumpState")
 		
 	if Input.is_action_just_pressed(play_char.crouch_action):

--- a/addons/PlayerCharacter/StateMachine/wallrun_state_script.gd
+++ b/addons/PlayerCharacter/StateMachine/wallrun_state_script.gd
@@ -21,10 +21,12 @@ func verifications() -> void:
 	play_char.move_deccel = play_char.wallrun_deccel
 	
 	if play_char.floor_snap_length != 1.0: play_char.floor_snap_length = 1.0
-	if play_char.jump_cooldown > 0.0: play_char.jump_cooldown = -1.0
-	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref: play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
-	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref: play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
-	if play_char.time_bef_can_wallrun_again < play_char.time_bef_can_wallrun_again_ref: play_char.time_bef_can_wallrun_again = play_char.time_bef_can_wallrun_again_ref
+	if play_char.nb_jumps_in_air_allowed < play_char.nb_jumps_in_air_allowed_ref:
+		play_char.nb_jumps_in_air_allowed = play_char.nb_jumps_in_air_allowed_ref
+	if play_char.coyote_jump_cooldown < play_char.coyote_jump_cooldown_ref:
+		play_char.coyote_jump_cooldown = play_char.coyote_jump_cooldown_ref
+	if play_char.time_bef_can_wallrun_again < play_char.time_bef_can_wallrun_again_ref:
+		play_char.time_bef_can_wallrun_again = play_char.time_bef_can_wallrun_again_ref
 	if play_char.has_dashed: play_char.has_dashed = false
 	
 	play_char.tween_hitbox_height(play_char.base_hitbox_height)
@@ -40,6 +42,9 @@ func physics_update(delta : float) -> void:
 	move(delta)
 	
 func applies(delta : float) -> void:
+	#Fix to make jump_cooldown run in this state.
+	#if play_char.jump_cooldown > 0.0: play_char.jump_cooldown -= delta
+
 	wallrun_forward_direction_calculus()
 	
 	if !play_char.infinite_wallrun_time:
@@ -61,7 +66,7 @@ func gravity_apply(delta: float) -> void:
 	
 func input_management() -> void:
 	if Input.is_action_just_pressed(play_char.jump_action):
-		if play_char.jump_cooldown < 0.0:
+		if play_char.jump_cooldown <= 0.0:
 			play_char.can_wallrun = false
 			play_char.about_to_jump_vel = play_char.velocity
 			transitioned.emit(self, "JumpState")


### PR DESCRIPTION
Issue 21 - Idle used move_deccel and didn't set itl, but sliding sets move-deccel to 0. I created an idle_deccel variable in PlayerCharacter.

I fixed your verifications bug. It was caused by using jump_cooldown < 0. I changed it to <= 0. You should no longer need to set it to jump_cooldown to -1 in all verifications, as it uses the parent variable. I created a function to iterate it as well.

By the way, great addon!